### PR TITLE
Integrate hil cli

### DIFF
--- a/bin/quads.py
+++ b/bin/quads.py
@@ -54,6 +54,10 @@ def main(argv):
         print "quads: Missing \"hardware_service\" in " + quads_config_file
         exit(1)
 
+    if "hardware_service_url" not in quads_config:
+        print "quads: Missing \"hardware_service_url\" in " + quads_config_file
+        exit(1)
+
     sys.path.append(quads_config["install_dir"] + "/lib")
     sys.path.append(os.path.dirname(__file__) + "/../lib")
     sys.path.append(os.path.dirname(__file__) + "/../lib/hardware_services/hardware_drivers/")
@@ -63,8 +67,9 @@ def main(argv):
     defaultstatedir = quads_config["data_dir"] + "/state"
     defaultmovecommand = "/bin/echo"
 
-    # EC528 addition - sets hardware service
+    # EC528 addition - sets hardware service and hardware service url (if provided)
     defaulthardwareservice = quads_config["hardware_service"]
+    defaulthardwareserviceurl = quads_config["hardware_service_url"]
 
 
     parser = argparse.ArgumentParser(description='Query current cloud for a given host')
@@ -111,7 +116,10 @@ def main(argv):
     parser.add_argument('--dry-run', dest='dryrun', action='store_true', default=None, help='Dont update state when used with --move-hosts')
     parser.add_argument('--log-path', dest='logpath',type=str,default=None, help='Path to quads log file')
 
-    parser.add_argument('--set-hardware-service', dest='hardwareservice', type=str, default=defaulthardwareservice, help='Set Hardware Serve');
+# command line options to set hardware service and hardware service url manually
+# added to maintain consistency with other config file parameters (which are set either in the config file or through the cli)
+    parser.add_argument('--set-hardware-service', dest='hardwareservice', type=str, default=defaulthardwareservice, help='Set Hardware Service');
+    parser.add_argument('--set-hardware-service-url', dest='hardwareserviceurl', type=str, default=defaulthardwareserviceurl, help='Set Hardware Service URL');
 
 
     args = parser.parse_args()
@@ -178,8 +186,7 @@ def main(argv):
     #   force -  Some operations require --force.  E.g. if you want to redefine
     #            a cloud environment.
 
-    quads = libquads.Quads(args.config, args.statedir, args.movecommand, args.datearg,
-                  args.syncstate, args.initialize, args.force, args.hardwareservice)
+    quads = libquads.Quads(args.config, args.statedir, args.movecommand, args.datearg, args.syncstate, args.initialize, args.force, args.hardwareservice, args.hardwareserviceurl)
 
     # should these be mutually exclusive?
     if args.lshosts:

--- a/conf/quads.yml
+++ b/conf/quads.yml
@@ -17,7 +17,7 @@ hardware_service: Hil
 # if hardware service provides an api server configure the following parameter
 # as of now only the Hil option makes calls to a server but this will allow easier future expansion and use of other services that require such a setup 
 # default is set to localhost on port 5000
-#hardware_service_url: http://127.0.0.1:5000
+hardware_service_url: http://127.0.0.1:5000
 
 
 # used for reporting

--- a/conf/quads.yml
+++ b/conf/quads.yml
@@ -10,9 +10,12 @@ log: /opt/quads/log/quads.log
 
 # EC528 addition - demo 4
 # set hardware service (inventory and network services) - currently 3 options: Mock, Hil, and QuadsNative 
-#hardware_service: Hil 
+hardware_service: Hil 
 #hardware_service: QuadsNative 
-hardware_service: Mock 
+#hardware_service: Mock 
+
+# if Hil option is used, uncomment the following line to configure the HIL server url (default is set to localhost on port 5000)
+hil_url: http://127.0.0.1:5000
 
 
 # used for reporting

--- a/conf/quads.yml
+++ b/conf/quads.yml
@@ -14,8 +14,10 @@ hardware_service: Hil
 #hardware_service: QuadsNative 
 #hardware_service: Mock 
 
-# if Hil option is used, uncomment the following line to configure the HIL server url (default is set to localhost on port 5000)
-hil_url: http://127.0.0.1:5000
+# if hardware service provides an api server configure the following parameter
+# as of now only the Hil option makes calls to a server but this will allow easier future expansion and use of other services that require such a setup 
+# default is set to localhost on port 5000
+#hardware_service_url: http://127.0.0.1:5000
 
 
 # used for reporting

--- a/lib/hardware_services/inventory_drivers/HilInventoryDriver.py
+++ b/lib/hardware_services/inventory_drivers/HilInventoryDriver.py
@@ -88,61 +88,24 @@ class HilInventoryDriver(InventoryService):
     # the following private methods are based on the HIL cli and are wrappers for the hil rest api calls #
     ######################################################################################################
 
-    def __urlify(self, url, *args):
-        """ strings together arguments in url format for rest call """
-
-        if url is None:
-            sys.exit("Error: Hil server url not specified")
-
-        for arg in args:
-            url += '/' + urllib.quote(arg, '')
-        return url
-
-    """ TODO move status check and rest call wrappers to libquads as static functions
-    """
-    def __status_check(self, response):
-        """ checks status codes to ensure rest call returned successfully """
-
-        if response.status_code < 200 or response.status_code >= 300:
-            sys.exit(response.text)
-        else:
-            return response
-
-
-    def __put(self, url, data={}):
-        self.__status_check(requests.put(url, data=json.dumps(data)))
-
-
-    def __post(self, url, data={}):
-        self.__status_check(requests.post(url, data=json.dumps(data)))
-
-
-    def __get(self, url, params=None):
-        return self.__status_check(requests.get(url, params=params))
-
-
-    def __delete(self, url):
-        self.__status_check(requests.delete(url))
-
-
     def __list_projects(self, hil_url):
-        url = self.__urlify(hil_url, 'projects')
-        return self.__get(url)
+        url = Quads.quads_urlify(hil_url, 'projects')
+        return Quads.quads_get(url)
 
 
     def __project_create_network(self, hil_url, project):
         """ creates network belonging to project of the same name """
 
-        url = self.__urlify(hil_url, 'network', project)
-        self.__put(url, data={'owner': project,
+        url = Quads.quads_urlify(hil_url, 'network', project)
+        Quads.quads_put(url, data={'owner': project,
                               'access': project,
                               'net_id': ""})
 
 
     def __project_create(self, hil_url, project):
         """ creates new project """
-        url = self.__urlify(hil_url, 'project', project)
-        self.__put(url)
+        url = Quads.quads_urlify(hil_url, 'project', project)
+        Quads.quads_put(url)
 
 
 

--- a/lib/hardware_services/inventory_drivers/HilInventoryDriver.py
+++ b/lib/hardware_services/inventory_drivers/HilInventoryDriver.py
@@ -14,6 +14,9 @@ import json
 import urllib
 from subprocess import call
 from subprocess import check_call
+from os import path
+sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
+from libquads import Quads
 
 from hardware_services.inventory_service import InventoryService
 

--- a/lib/hardware_services/inventory_drivers/HilInventoryDriver.py
+++ b/lib/hardware_services/inventory_drivers/HilInventoryDriver.py
@@ -12,6 +12,7 @@ import requests
 import logging
 import json
 import urllib
+import time
 from subprocess import call
 from subprocess import check_call
 from os import path
@@ -57,6 +58,9 @@ class HilInventoryDriver(InventoryService):
         node_info = self.__show_node(hilurl, host).json()
         for nic in node_info['nics']:        # a node in quads will only have one nic per network
             self.__node_detach_network(hilurl, host, nic['label'], node_info['project'])
+
+        # Hil network server needs time to process request
+        time.sleep(2)
 
         # then detach host from project
         self.__project_detach_node(hilurl, node_info['project'], host)
@@ -148,10 +152,9 @@ class HilInventoryDriver(InventoryService):
         return Quads.quads_get(url)
 
 
-    def __node_connect_network(self, hil_url, node, nic, network, channel='null'):
+    def __node_connect_network(self, hil_url, node, nic, network, channel=None):
         url = Quads.quads_urlify(hil_url, 'node', node, 'nic', nic, 'connect_network')
-        Quads.quads_post(url, data={'network': network,
-                                    'channel': channel})
+        Quads.quads_post(url, data={'network': network })
 
 
     def __node_detach_network(self, hil_url, node, nic, network):

--- a/lib/hardware_services/inventory_drivers/HilInventoryDriver.py
+++ b/lib/hardware_services/inventory_drivers/HilInventoryDriver.py
@@ -61,4 +61,22 @@ class HilInventoryDriver(InventoryService):
         print hosts.text
 
 
+    def load_data(self, quads, force):
+        """
+        """
+
+    def init_data(self, quads, force):
+        """
+        """
+
+    def sync_state(self, quads):
+        """
+        """
+
+    def write_data(self, quads, doexit = True):
+        """
+        """
+
+
+
 

--- a/lib/libquads.py
+++ b/lib/libquads.py
@@ -671,7 +671,7 @@ class Quads(object):
         """ strings together arguments in url format for rest call """
 
         if url is None:
-            sys.exit("Error: Hil server url not specified")
+            sys.exit("Error: server url not specified")
 
         for arg in args:
             url += '/' + urllib.quote(arg, '')
@@ -683,7 +683,7 @@ class Quads(object):
         """ checks status codes to ensure rest call returned successfully """
 
         if response.status_code < 200 or response.status_code >= 300:
-            sys.exit(response.text)
+            sys.exit("Error: request returned: " + response.text)
         else:
             return response
 

--- a/lib/libquads.py
+++ b/lib/libquads.py
@@ -6,6 +6,7 @@ import requests
 import logging
 import sys
 import importlib
+import urllib
 from subprocess import check_call
 from hardware_services.inventory_service import get_inventory_service, set_inventory_service
 from hardware_services.network_service import get_network_service, set_network_service
@@ -659,5 +660,52 @@ class Quads(object):
         r = requests.request(method, url + request, data=json_data)
         if method == 'GET':
             return r
+
+    # the following class methods are added as utility functions for making calls to restful APIs,
+    # currently they are only used by the HIL drivers, but they are written generically so they can be
+    # reused if QUADS needs to interface with any other application in the future via http
+
+    @classmethod
+    def quads_urlify(self, url, *args):
+        """ strings together arguments in url format for rest call """
+
+        if url is None:
+            sys.exit("Error: Hil server url not specified")
+
+        for arg in args:
+            url += '/' + urllib.quote(arg, '')
+        return url
+
+
+    @classmethod
+    def quads_status_code_check(self, response):
+        """ checks status codes to ensure rest call returned successfully """
+
+        if response.status_code < 200 or response.status_code >= 300:
+            sys.exit(response.text)
+        else:
+            return response
+
+
+    @classmethod
+    def quads_put(self, url, data={}):
+        quads_status_check(requests.put(url, data=json.dumps(data)))
+
+
+    @classmethod
+    def quads_post(self, url, data={}):
+        quads_status_code_check(requests.post(url, data=json.dumps(data)))
+
+
+    @classmethod
+    def quads_get(self, url, params=None):
+        return quads_status_code_check(requests.get(url, params=params))
+
+
+    @classmethod
+    def quads_delete(self, url):
+        quads_status_code_check(requests.delete(url))
+
+
 
 

--- a/lib/libquads.py
+++ b/lib/libquads.py
@@ -7,6 +7,7 @@ import logging
 import sys
 import importlib
 import urllib
+import json
 from subprocess import check_call
 from hardware_services.inventory_service import get_inventory_service, set_inventory_service
 from hardware_services.network_service import get_network_service, set_network_service
@@ -689,22 +690,22 @@ class Quads(object):
 
     @classmethod
     def quads_put(self, url, data={}):
-        quads_status_check(requests.put(url, data=json.dumps(data)))
+        self.quads_status_code_check(requests.put(url, data=json.dumps(data)))
 
 
     @classmethod
     def quads_post(self, url, data={}):
-        quads_status_code_check(requests.post(url, data=json.dumps(data)))
+        self.quads_status_code_check(requests.post(url, data=json.dumps(data)))
 
 
     @classmethod
     def quads_get(self, url, params=None):
-        return quads_status_code_check(requests.get(url, params=params))
+        return self.quads_status_code_check(requests.get(url, params=params))
 
 
     @classmethod
     def quads_delete(self, url):
-        quads_status_code_check(requests.delete(url))
+        self.quads_status_code_check(requests.delete(url))
 
 
 

--- a/lib/libquads.py
+++ b/lib/libquads.py
@@ -90,7 +90,7 @@ class QuadsData(object):
 
 class Quads(object):
 
-    def __init__(self, config, statedir, movecommand, datearg, syncstate, initialize, force, hardwareservice):
+    def __init__(self, config, statedir, movecommand, datearg, syncstate, initialize, force, hardwareservice, hardwareserviceurl):
         """
         Initialize a quads object.
         """
@@ -113,6 +113,9 @@ class Quads(object):
 
         self.inventory_service = get_inventory_service()
         self.network_service = get_network_service()
+
+        self.hardware_service_url = hardwareserviceurl
+
 
         if initialize:
             self.quads_init_data(force)

--- a/testing/test_inventory.py
+++ b/testing/test_inventory.py
@@ -24,8 +24,8 @@ def quads_init():
     args = Test_Inventory.quads + " --define-cloud cloud02 --description cloud02"
     sp.call(args, shell=True)
 
-    args = Test_Inventory.quads + " --define-host host01 --default-cloud cloud02"	
-    sp.call(args, shell=True) == 1	
+    args = Test_Inventory.quads + " --define-host host01 --default-cloud cloud02"
+    sp.call(args, shell=True) == 1
 
 @pytest.fixture(scope='function')
 def quads_config():
@@ -33,54 +33,54 @@ def quads_config():
 
 class Test_Inventory:
     quads = "../bin/quads.py"
-   
+
     def test_quads_init_fail(self):
-       
+
         args = Test_Inventory.quads + " --init"
         assert sp.call(args, shell=True) == 1
 
     def test_quads_init_pass(self):
-       
+
         args = Test_Inventory.quads + " --init --force"
         assert sp.call(args, shell=True) == 0
 
     def test_update_clouds_pass(self):
-        
+
         args = Test_Inventory.quads + " --define-cloud cloud03 --description cloud03"
         assert sp.call(args, shell=True) == 0
-   
+
     def test_update_clouds_fail(self):
-        
+
         args = Test_Inventory.quads + " --define-cloud cloud01 --description cloud01"
         assert sp.call(args, shell=True) == 1
-       
+
     def test_update_hosts_pass(self):
-       
+
         args = Test_Inventory.quads + " --define-host host05 --default-cloud cloud01"
         assert sp.call(args, shell=True) == 0
 
     def test_update_hosts_fail(self):
-       
-        args = Test_Inventory.quads + " --define-host host01 --default-cloud cloud02"	
-        assert sp.call(args, shell=True) == 1      
-       
+
+        args = Test_Inventory.quads + " --define-host host01 --default-cloud cloud02"
+        assert sp.call(args, shell=True) == 1
+
     def test_remove_host_pass(self):
-       
+
         args = Test_Inventory.quads + " --rm-host host01"
         assert sp.call(args, shell=True) == 0
 
     def test_remove_host_fail(self):
-       
+
         args = Test_Inventory.quads + " --rm-host host10"
         assert sp.call(args, shell=True) == 1
-       
+
     def test_remove_cloud_pass(self):
-       
+
         args = Test_Inventory.quads + " --rm-cloud cloud01"
         assert sp.call(args, shell=True) == 0
 
     def test_remove_cloud_fail(self):
-       
+
         args = Test_Inventory.quads + " --rm-cloud cloud10"
         assert sp.check_output(args, shell=True) == 'cloud10 not found\n'
 
@@ -88,32 +88,32 @@ class Test_Inventory:
 
 	args = Test_Inventory.quads + " --define-host host01 --default-cloud cloud01"
         sp.call(args, shell=True)
-       
+
         args = Test_Inventory.quads + " --ls-hosts"
         assert sp.check_output(args, shell=True) == "host01\n"
-       
+
     def test_list_hosts_fail(self):
-       
+
         args = Test_Inventory.quads + " --ls-hosts"
 	with pytest.raises(AssertionError):
             assert sp.check_output(args, shell=True) == "listing"
-       
+
     def test_list_clouds_pass(self):
-       
+
         args = Test_Inventory.quads + " --ls-clouds"
         assert sp.check_output(args, shell=True) == "cloud01\ncloud02\n"
 
     def test_list_clouds_fail(self):
-       
+
         args = Test_Inventory.quads + " --ls-clouds"
 	with pytest.raises(AssertionError):
             assert sp.check_output(args, shell=True) == "cloud02\n"
 
-           
+
     def test_write_data(self):
-       
+
         pass
-       
+
     def test_sync_state(self):
-       
+
         pass


### PR DESCRIPTION
(@portante I forgot to squash the commits before pushing to my origin, and then could no longer squash them. Is there a way to just make a pull request for the final commit, or squash them before merging? )

Note: If cloning branch to test, must have HIL api server and HIL network server running for the HilInventoryDriver to work) 

modify hil-specific methods from hil/haas/cli.py (adapted by @vsemp) into
private helper methods in the HilInventoryDriver in order to provide a
simplifying layer of abstraction to make the code more readable and developer
friendly, while keeping all hil-specific actions encapsulated within the scope
of the hil-specific drivers. Remove hil dependencies from the rest call wrappers,
url creater, and status code checker and add them as class methods to the Quads
object in libquads. The methods were primarily inventory related and are
therefore placed in the HilInventoryDriver class. The HilNetworkDriver class
can access the inventory information it needs through use of a HilInventoryDriver
instance

The following changes were made to the following files:

    - lib/hardware_services/inventory_drivers/HilInventoryDriver.py:
        - implement new private methods:
            - __list_projects
            - __project_create_network
            - __project_connect_node
            - __project_detach_node
            - __network_delete
            - __project_create
            - __project_delete
            - __list_nodes
            - __show_node
            - __node_connect_network
            - __node_detach_network

        - refactor existing public methods to use new private methods:
            - update_cloud
            - update_host
            - remove_cloud
            - remove_host
            - list_clouds
            - list_hosts

    - lib/libquads.py:
        - add class methods to wrap rest calls:
            - quads_urlify
            - quads_status_code_check
            - quads_put
            - quads_post
            - quads_get
            - quads_delete

        - add new member variable for api server url:
            - hardware_service_url

    - conf/quads.yml:
        - add hardware_service_url parameter in config file
            so it can be easily expanded to use other APIs than HIL

    - bin/quads.py
        - add defaulthardwareserviceurl variable set to new config parameter
        - add --set-hardware-service-url command line option to set parameter
            dynamically