### PR TITLE
adapt HIL cli as private helper methods for hil drivers

### DIFF
--- a/bin/quads.py
+++ b/bin/quads.py
@@ -57,16 +57,24 @@ def main(argv):
         print "quads: Missing \"hardware_service\" in " + quads_config_file
         exit(1)
 
+    if "hardware_service_url" not in quads_config:
+        print "quads: Missing \"hardware_service_url\" in " + quads_config_file
+        exit(1)
+
     sys.path.append(os.path.join(quads_config["install_dir"], "lib"))
     sys.path.append(os.path.join(os.path.dirname(__file__), "..", "lib"))
     import Quads
+
+    sys.path.append(os.path.join(os.path.dirname(__file__), "..", "lib/hardware_services/hardware_drivers"))
+
 
     defaultconfig = os.path.join(quads_config["data_dir"], "schedule.yaml")
     defaultstatedir = os.path.join(quads_config["data_dir"], "state")
     defaultmovecommand = "/bin/echo"
 
-    # EC528 addition - sets hardware service
+    # EC528 addition - sets hardware service and hardware service url (if provided)
     defaulthardwareservice = quads_config["hardware_service"]
+    defaulthardwareserviceurl = quads_config["hardware_service_url"]
 
     # added for EC528 HIL-QUADS integration project - not a good place for this variable - should be moved eventually
     hil_url = 'http://127.0.0.1:5000'
@@ -114,9 +122,11 @@ def main(argv):
     parser.add_argument('--move-command', dest='movecommand', type=str, default=defaultmovecommand, help='External command to move a host')
     parser.add_argument('--dry-run', dest='dryrun', action='store_true', default=None, help='Dont update state when used with --move-hosts')
     parser.add_argument('--log-path', dest='logpath',type=str,default=None, help='Path to quads log file')
-    parser.add_argument('--hil-api-action', dest='hilapiaction', type=str, default=None, help='HIL API Action');
-    parser.add_argument('--hil-api-call', dest='hilapicall', type=str, default=None, help='HIL API Call');
-    parser.add_argument('--set-hardware-service', dest='hardwareservice', type=str, default=defaulthardwareservice, help='Set Hardware Serve');
+
+    # command line options to set hardware service and hardware service url manually
+    # added to maintain consistency with other config file parameters (which are set either in the config file or through the cli)
+    parser.add_argument('--set-hardware-service', dest='hardwareservice', type=str, default=defaulthardwareservice, help='Set Hardware Service');
+    parser.add_argument('--set-hardware-service-url', dest='hardwareserviceurl', type=str, default=defaulthardwareserviceurl, help='Set Hardware Service URL');
 
     args = parser.parse_args()
 
@@ -184,8 +194,8 @@ def main(argv):
     #
     #   hardwareservice - ????
     #
-    quads = Quads(args.config, args.statedir, args.movecommand, args.datearg,
-                  args.syncstate, args.initialize, args.force, args.hardwareservice)
+
+    quads = Quads.Quads(args.config, args.statedir, args.movecommand, args.datearg, args.syncstate, args.initialize, args.force, args.hardwareservice, args.hardwareserviceurl)
 
     # should these be mutually exclusive?
     if args.lshosts:

--- a/bin/quads.py
+++ b/bin/quads.py
@@ -11,7 +11,6 @@ import logging
 import requests
 from subprocess import call
 from subprocess import check_call
-from Quads import Quads
 
 sys.path.append(os.path.dirname(__file__) + "/../")
 #from lib.hardware_services.hardware_service import set_hardware_service
@@ -40,7 +39,6 @@ def quads_load_config(quads_config):
     return(quads_config_yaml)
 
 def main(argv):
-    quads_config_file = os.path.dirname(__file__) + "/../conf/quads.yml"
     quads_config_file = os.path.join(os.path.dirname(__file__), "..", "conf", "quads.yml")
     quads_config = quads_load_config(quads_config_file)
 

--- a/conf/quads.yml
+++ b/conf/quads.yml
@@ -14,6 +14,11 @@ log: /opt/quads/log/quads.log
 #hardware_service: QuadsNative
 hardware_service: Mock
 
+# if hardware service provides an api server configure the following parameter
+# as of now only the Hil option makes calls to a server but this will allow easier future expansion and use of other services that require such a setup 
+# default is set to localhost on port 5000
+hardware_service_url: http://127.0.0.1:5000
+
 
 # used for reporting
 report_cc: someuser@example.com, someuser@example.com, someuser@example.com, someuser@example.com

--- a/lib/hardware_services/inventory_drivers/HilInventoryDriver.py
+++ b/lib/hardware_services/inventory_drivers/HilInventoryDriver.py
@@ -11,54 +11,189 @@ import sys
 import requests
 import logging
 import json
+import urllib
+import time
 from subprocess import call
 from subprocess import check_call
+from os import path
+sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
+from libquads import Quads
 
 from hardware_services.inventory_service import InventoryService
 
-# added for EC528 HIL-QUADS integration project
-hil_url = 'http://127.0.0.1:5000'
 
 class HilInventoryDriver(InventoryService):
 
 
     def update_cloud(self, quadsinstance, **kwargs):
-        quadsinstance.quads_rest_call('PUT', hil_url, '/project/' + kwargs['cloudresource'])
-        quadsinstance.quads_rest_call('PUT', hil_url, '/network/' + kwargs['cloudresource'], json.dumps({"owner": kwargs['cloudresource'], "access": kwargs['cloudresource'], "net_id": ""}))
+        self.__project_create(quadsinstance.hardware_service_url, kwargs['cloudresource'])
+        self.__project_create_network(quadsinstance.hardware_service_url, kwargs['cloudresource'])
 
 
     def update_host(self, quadsinstance, **kwargs):
-        quadsinstance.quads_rest_call('POST', hil_url, '/project/' + kwargs['hostcloud'] + '/connect_node', json.dumps({'node': kwargs['hostresource']}))
-        node_info = quadsinstance.quads_rest_call('GET', hil_url, '/node/' + kwargs['hostresource'])
-        node = node_info.json()
-        for nic in node['nics']:        # a node in quads will only have one nic per network
-            quadsinstance.quads_rest_call('POST', hil_url, '/node/' + kwargs['hostresource'] + '/nic/' + nic['label'] + '/connect_network', json.dumps({'network': kwargs['hostcloud']}))
+        cloud = kwargs['hostcloud']
+        host = kwargs['hostresource']
+        hilurl = quadsinstance.hardware_service_url
+
+        self.__project_connect_node(hilurl, cloud, host)
+        node_info = self.__show_node(hilurl, host).json()
+        for nic in node_info['nics']:        # a node in quads will only have one nic per network
+            self.__node_connect_network(hilurl, host, nic['label'], cloud)
 
 
 
     def remove_cloud(self, quadsinstance, **kwargs):
-        targetProject = kwargs['rmcloud']
-        quadsinstance.quads_rest_call("DELETE", hil_url, '/network/'+ targetProject)
-        quadsinstance.quads_rest_call("DELETE", hil_url, '/project/'+ targetProject)
+        cloud = kwargs['rmcloud']
+        self.__network_delete(quadsinstance.hardware_service_url, cloud)
+        self.__project_delete(quadsinstance.hardware_service_url, cloud)
 
 
     def remove_host(self,quadsinstance, **kwargs):
+        host = kwargs['rmhost']
+        hilurl = quadsinstance.hardware_service_url
+
         # first detach host from network
-        node_info = quadsinstance.quads_rest_call('GET', hil_url, '/node/' + kwargs['rmhost'])
-        node = node_info.json()
-        for nic in node['nics']:        # a node in quads will only have one nic per network
-            quadsinstance.quads_rest_call('POST', hil_url, '/node/' + kwargs['rmhost'] + '/nic/' + nic['label'] + '/detach_network', json.dumps({'network': node['project']}))
+        node_info = self.__show_node(hilurl, host).json()
+        for nic in node_info['nics']:        # a node in quads will only have one nic per network
+            self.__node_detach_network(hilurl, host, nic['label'], node_info['project'])
+
+
+        # then detach host from project
+        self.__project_detach_node(hilurl, node_info['project'], host)
+
 
 
     def list_clouds(self, quadsinstance):
-        projects = quadsinstance.quads_rest_call("GET", hil_url, '/projects')
-        print projects.text
+        #projects = quadsinstance.quads_rest_call("GET", hil_url, '/projects')
+        #print projects.text
+        print self.__list_projects(quadsinstance.hardware_service_url).text
 
 
     def list_hosts(self, quadsinstance):
-        hosts = quadsinstance.quads_rest_call("GET", hil_url, '/nodes/all')
+        hosts = self.__list_nodes(quadsinstance.hardware_service_url)
         #hosts_yml = yaml.dump(json.loads(hosts.text), default_flow_style=False)
         print hosts.text
+
+
+    def load_data(self, quads, force):
+        """
+        """
+
+    def init_data(self, quads, force):
+        """
+        """
+
+    def sync_state(self, quads):
+        """
+        """
+
+    def write_data(self, quads, doexit = True):
+        """
+        """
+
+    ######################################################################################################
+    # the following private methods are based on the HIL cli and are wrappers for the hil rest api calls #
+    ######################################################################################################
+
+    def __list_projects(self, hil_url):
+        """ lists all projects """
+
+        url = Quads.quads_urlify(hil_url, 'projects')
+        return Quads.quads_get(url)
+
+
+    def __project_create_network(self, hil_url, project):
+        """ creates network belonging to project of the same name """
+
+        url = Quads.quads_urlify(hil_url, 'network', project)
+        Quads.quads_put(url, data={'owner': project,
+                              'access': project,
+                              'net_id': ""})
+
+
+    def __project_connect_node(self, hil_url, project, node):
+        """ connects node to project """
+
+        url = Quads.quads_urlify(hil_url, 'project', project, 'connect_node')
+        Quads.quads_post(url, data={'node': node})
+
+
+    def __project_detach_node(self, hil_url, project, node):
+        """ Detaches node from project. Will fail if node is connected to any project networks """
+
+        url = Quads.quads_urlify(hil_url, 'project', project, 'detach_node')
+        Quads.quads_post(url, data={'node': node })
+
+
+    def __network_delete(self, hil_url, network):
+        """ Deletes network. Will fail if network has nodes connected to it """
+
+        url = Quads.quads_urlify(hil_url, 'network', network)
+        Quads.quads_delete(url)
+
+
+    def __project_create(self, hil_url, project):
+        """ creates new project """
+        url = Quads.quads_urlify(hil_url, 'project', project)
+        Quads.quads_put(url)
+
+
+    def __project_delete(self, hil_url, project):
+        """ Deletes project. Will fail if project has any connected nodes or networks """
+        url = Quads.quads_urlify(hil_url, 'project', project)
+        Quads.quads_delete(url)
+
+
+    def __list_nodes(self, hil_url, is_free='all'):
+        """ lists nodes. If is_free is set to free, only lists unallocated nodes """
+
+        if is_free not in ('all', 'free'):
+            sys.exit("error listing hosts. is_free is not set to all or free")
+        url = Quads.quads_urlify(hil_url, 'nodes', is_free)
+        return Quads.quads_get(url)
+
+
+    def __show_node(self, hil_url, node):
+        """ returns data associated with specified node """
+
+        url = Quads.quads_urlify(hil_url, 'node', node)
+        return Quads.quads_get(url)
+
+
+    def __node_connect_network(self, hil_url, node, nic, network, channel=None):
+        """ connects specified node to specified network on the specified nic """
+
+        """ If channel is None, it is set automatically to the default value on the HIL server side, however is kept here as a
+        parameter in case it ever needs to be specified. """
+
+        if channel is not None:
+            network_data = { 'network': network,
+                             'channel': channel }
+        else:
+            network_data = { 'network': network }
+
+        url = Quads.quads_urlify(hil_url, 'node', node, 'nic', nic, 'connect_network')
+        Quads.quads_post(url, data=network_data)
+
+        # Hil network server needs time to process request
+        time.sleep(2)
+
+
+    def __node_detach_network(self, hil_url, node, nic, network):
+        """ detaches node from network """
+
+        url = Quads.quads_urlify(hil_url, 'node', node, 'nic', nic, 'detach_network')
+        Quads.quads_post(url, data={'network': network})
+
+        # Hil network server needs time to process request
+        time.sleep(2)
+
+
+
+
+
+
+
 
 
 

--- a/testing/test_inventory.py
+++ b/testing/test_inventory.py
@@ -24,8 +24,8 @@ def quads_init():
     args = Test_Inventory.quads + " --define-cloud cloud02 --description cloud02"
     sp.call(args, shell=True)
 
-    args = Test_Inventory.quads + " --define-host host01 --default-cloud cloud02"	
-    sp.call(args, shell=True) == 1	
+    args = Test_Inventory.quads + " --define-host host01 --default-cloud cloud02"
+    sp.call(args, shell=True) == 1
 
 @pytest.fixture(scope='function')
 def quads_config():
@@ -33,54 +33,54 @@ def quads_config():
 
 class Test_Inventory:
     quads = "../bin/quads.py"
-   
+
     def test_quads_init_fail(self):
-       
+
         args = Test_Inventory.quads + " --init"
         assert sp.call(args, shell=True) == 1
 
     def test_quads_init_pass(self):
-       
+
         args = Test_Inventory.quads + " --init --force"
         assert sp.call(args, shell=True) == 0
 
     def test_update_clouds_pass(self):
-        
+
         args = Test_Inventory.quads + " --define-cloud cloud03 --description cloud03"
         assert sp.call(args, shell=True) == 0
-   
+
     def test_update_clouds_fail(self):
-        
+
         args = Test_Inventory.quads + " --define-cloud cloud01 --description cloud01"
         assert sp.call(args, shell=True) == 1
-       
+
     def test_update_hosts_pass(self):
-       
+
         args = Test_Inventory.quads + " --define-host host05 --default-cloud cloud01"
         assert sp.call(args, shell=True) == 0
 
     def test_update_hosts_fail(self):
-       
-        args = Test_Inventory.quads + " --define-host host01 --default-cloud cloud02"	
-        assert sp.call(args, shell=True) == 1      
-       
+
+        args = Test_Inventory.quads + " --define-host host01 --default-cloud cloud02"
+        assert sp.call(args, shell=True) == 1
+
     def test_remove_host_pass(self):
-       
+
         args = Test_Inventory.quads + " --rm-host host01"
         assert sp.call(args, shell=True) == 0
 
     def test_remove_host_fail(self):
-       
+
         args = Test_Inventory.quads + " --rm-host host10"
         assert sp.call(args, shell=True) == 1
-       
+
     def test_remove_cloud_pass(self):
-       
+
         args = Test_Inventory.quads + " --rm-cloud cloud01"
         assert sp.call(args, shell=True) == 0
 
     def test_remove_cloud_fail(self):
-       
+
         args = Test_Inventory.quads + " --rm-cloud cloud10"
         assert sp.check_output(args, shell=True) == 'cloud10 not found\n'
 
@@ -88,32 +88,32 @@ class Test_Inventory:
 
 	args = Test_Inventory.quads + " --define-host host01 --default-cloud cloud01"
         sp.call(args, shell=True)
-       
+
         args = Test_Inventory.quads + " --ls-hosts"
         assert sp.check_output(args, shell=True) == "host01\n"
-       
+
     def test_list_hosts_fail(self):
-       
+
         args = Test_Inventory.quads + " --ls-hosts"
 	with pytest.raises(AssertionError):
             assert sp.check_output(args, shell=True) == "listing"
-       
+
     def test_list_clouds_pass(self):
-       
+
         args = Test_Inventory.quads + " --ls-clouds"
         assert sp.check_output(args, shell=True) == "cloud01\ncloud02\n"
 
     def test_list_clouds_fail(self):
-       
+
         args = Test_Inventory.quads + " --ls-clouds"
 	with pytest.raises(AssertionError):
             assert sp.check_output(args, shell=True) == "cloud02\n"
 
-           
+
     def test_write_data(self):
-       
+
         pass
-       
+
     def test_sync_state(self):
-       
+
         pass


### PR DESCRIPTION
modify hil-specific methods from hil/haas/cli.py (adapted by @vsemp) into
private helper methods in the HilInventoryDriver in order to provide a
simplifying layer of abstraction to make the code more readable and developer
friendly, while keeping all hil-specific actions encapsulated within the scope
of the hil-specific drivers. Remove hil dependencies from the rest call wrappers,
url creater, and status code checker and add them as class methods to the Quads
object in libquads. The methods were primarily inventory related and are
therefore placed in the HilInventoryDriver class. The HilNetworkDriver class
can access the inventory information it needs through use of a HilInventoryDriver
instance

The following changes were made to the following files:

    - lib/hardware_services/inventory_drivers/HilInventoryDriver.py:
        - implement new private methods:
            - __list_projects
            - __project_create_network
            - __project_connect_node
            - __project_detach_node
            - __network_delete
            - __project_create
            - __project_delete
            - __list_nodes
            - __show_node
            - __node_connect_network
            - __node_detach_network

        - refactor existing public methods to use new private methods:
            - update_cloud
            - update_host
            - remove_cloud
            - remove_host
            - list_clouds
            - list_hosts

    - lib/libquads.py:
        - add class methods to wrap rest calls:
            - quads_urlify
            - quads_status_code_check
            - quads_put
            - quads_post
            - quads_get
            - quads_delete

        - add new member variable for api server url:
            - hardware_service_url

    - conf/quads.yml:
        - add hardware_service_url parameter in config file
            so it can be easily expanded to use other APIs than HIL

    - bin/quads.py
        - add defaulthardwareserviceurl variable set to new config parameter
        - add --set-hardware-service-url command line option to set parameter
            dynamically